### PR TITLE
Fix index.js export value

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,4 +4,4 @@ require('angular-material');
 require('material-design-icons');
 require('./dist/mdKeyboard');
 
-module.exports = 'mdKeyboard';
+module.exports = 'material.components.keyboard';


### PR DESCRIPTION
index.js should export this module's name to be able to use it directly as an angular module dependency name like this:

```javascript
import angular from 'angular';
import mdKeyboard from 'angular-material-keyboard';

angular.module('some_module', [mkKeyboard]);
```